### PR TITLE
Prepare for 14.0 version

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion" : "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2020.4",
+	"addon_lastTestedNVDAVersion" : "2021.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,11 @@ These are the key commands available by default, you can edit those or add new k
 
 Note: On Windows 10, it's also possible to use the built-in emoji panel.
 
+
+## Changes for 14.0 ##
+
+* Compatible with NVDA 2021.1 and beyond.
+
 ## Changes for 13.0 ##
 
 * Fixed errors in Insert Emoticon dialog.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Add compatibility with NVDA 2021.1
### Description of how this pull request fixes the issue:
Searched changes for developer with git grep and looking at the code after linting. Since there aren't changes affecting the add-on, update manifest (buildVars.py) and readme.
### Testing performed:
None yet.
### Known issues with pull request:
None
### Change log entry:
* Compatible with NVDA 2021.1 and beyond.