### PR TITLE
Add ability to associate gestures to copy symbols

### DIFF
--- a/addon/globalPlugins/insertSymbol/__init__.py
+++ b/addon/globalPlugins/insertSymbol/__init__.py
@@ -3,11 +3,10 @@
 # Released under GPL 2
 
 import globalPluginHandler
-import api
 import characterProcessing
-import copy
 import speech
-import ui
+import copy
+import brailleInput
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
@@ -38,12 +37,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	@classmethod
 	def _symbolScript(cls, symbol):
-		if api.copyToClip(symbol.identifier):
-			# Translators: This is the message when smiley has been copied to the clipboard.
-			ui.message(_("Smiley copied to clipboard, ready for you to paste."))
-		else:
-			# Translators: Message when the emoticon couldn't be copied.
-			ui.message(_("Cannot copy smiley."))
+		brailleInput.handler.sendChars(symbol.identifier)
 
 	@classmethod
 	def addScriptForSymbol(cls, symbol):

--- a/addon/globalPlugins/insertSymbol/__init__.py
+++ b/addon/globalPlugins/insertSymbol/__init__.py
@@ -1,0 +1,54 @@
+# -*- coding: UTF-8 -*-
+# Copyright (C) 2021 Noelia Ruiz Martínez
+# Released under GPL 2
+
+import globalPluginHandler
+import api
+import characterProcessing
+import copy
+import speech
+import ui
+
+class GlobalPlugin(globalPluginHandler.GlobalPlugin):
+
+	# Translators: Script category for commands to insert symbols.
+	scriptCategory = _("Insert symbols")
+
+	@classmethod
+	def __new__(cls, *args, **kwargs):
+		# Iterate through the available symbols, creating scripts for them.
+		for symbol in cls.getSymbols():
+			cls.addScriptForSymbol(symbol)
+		return super(GlobalPlugin, cls).__new__(cls)
+
+	@classmethod
+	def getSymbols(cls):
+		try:
+			symbolProcessor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData(speech.getCurrentLanguage())
+		except LookupError:
+			symbolProcessor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData("en")
+		symbols= [copy.copy(symbol) for symbol in symbolProcessor.computedSymbols.values()]
+		return symbols
+
+	@classmethod
+	def _getScriptNameForSymbol(cls, symbol):
+		name = symbol.replacement.replace(" ", "_")
+		return "symbol_%s" % name
+
+	@classmethod
+	def _symbolScript(cls, symbol):
+		if api.copyToClip(symbol.identifier):
+			# Translators: This is the message when smiley has been copied to the clipboard.
+			ui.message(_("Smiley copied to clipboard, ready for you to paste."))
+		else:
+			# Translators: Message when the emoticon couldn't be copied.
+			ui.message(_("Cannot copy smiley."))
+
+	@classmethod
+	def addScriptForSymbol(cls, symbol):
+		script = lambda self, gesture: cls._symbolScript(symbol)
+		funcName = script.__name__ = "script_%s" % cls._getScriptNameForSymbol(symbol)
+		# Just set the doc string of the script, using the decorator is overkill here.
+		# Translators: Message presented in input help mode.
+		script.__doc__ = _("Inserts the %s symbol" % symbol.replacement)
+		setattr(cls, funcName, script)

--- a/addon/globalPlugins/insertSymbol/__init__.py
+++ b/addon/globalPlugins/insertSymbol/__init__.py
@@ -38,6 +38,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@classmethod
 	def _symbolScript(cls, symbol):
 		brailleInput.handler.sendChars(symbol.identifier)
+		speech.speakTypedCharacters(symbol.identifier)
 
 	@classmethod
 	def addScriptForSymbol(cls, symbol):

--- a/addon/globalPlugins/insertSymbol/__init__.py
+++ b/addon/globalPlugins/insertSymbol/__init__.py
@@ -9,6 +9,7 @@ import copy
 import speech
 import ui
 
+
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	# Translators: Script category for commands to insert symbols.
@@ -24,10 +25,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@classmethod
 	def getSymbols(cls):
 		try:
-			symbolProcessor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData(speech.getCurrentLanguage())
+			processor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData(speech.getCurrentLanguage())
 		except LookupError:
-			symbolProcessor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData("en")
-		symbols= [copy.copy(symbol) for symbol in symbolProcessor.computedSymbols.values()]
+			processor = characterProcessing._localeSpeechSymbolProcessors.fetchLocaleData("en")
+		symbols = [copy.copy(symbol) for symbol in processor.computedSymbols.values()]
 		return symbols
 
 	@classmethod
@@ -46,7 +47,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	@classmethod
 	def addScriptForSymbol(cls, symbol):
-		script = lambda self, gesture: cls._symbolScript(symbol)
+		script = lambda self, gesture: cls._symbolScript(symbol)  # Noqa E731
 		funcName = script.__name__ = "script_%s" % cls._getScriptNameForSymbol(symbol)
 		# Just set the doc string of the script, using the decorator is overkill here.
 		# Translators: Message presented in input help mode.

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,12 @@ When you press OK, the characters for the chosen emoticon will be copied to your
 
 This dialog allows you to choose one of the symbols available in the Punctuation/symbol pronunciation dialog of NVDA. You can use the Filter edit box or the arrow keys to select an item from the symbols list. Then, press OK and the selected emoji or symbol will be copied to your clipboard, ready for pasting.
 
+## ## Associate gestures to symbols ###
+
+From NVDA's menu, Preferences submenu, Input gestures dialog, category Insert symbols, you can configure NVDA to type symbols through associated gestures.
+
+You can use the Edit field edit box to reduce the number of symbols presented, so that this category can be expanded faster.
+
 ## Emoticons dictionary ##
 
 Emoticons add-on allows to have differents speech-dictionaries using configuration profiles.
@@ -69,6 +75,9 @@ These are the key commands available by default, you can edit those or add new k
 
 Note: On Windows 10, it's also possible to use the built-in emoji panel.
 
+## Changes ##
+
+* Added ability to associate gestures to type symbols.
 
 ## Changes for 14.0 ##
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Closes issue #28 
### Summary of the issue:
Currently it's not possible to copy symbols just using gestures and opening dialogs is needed for this.
### Description of how this pull request fixes the issue:
Inspired by work made by @leonardder to add scripts for configuration profiles in NVDA. A new global plugin is added to the add-on with a class that adds a script for each available symbol (from characterProcessing, for the locale processor), so that gestures can be added/removed from the input gestures dialog, from Insert symbols category.
### Testing performed:
- Filter symbols using their description in input gestures dialog.
- Add gesture and copy a symbol.
### Known issues with pull request:
- If symbols aren't filtered, opening the Insert symbols category in input gestures dialog can take several seconds.
- When searching a symbol with the Insert symbols category opened, NVDA plays sound errors in beta. This is not specific for this add-on. Seems that it's a general issue happening when add-ons use extra categories, according to test made with instantTranslate.
### Change log entry:
* Added ability to add gestures for copying symbols.