### PR TITLE
Disable on secure screens, code provided by @CyrilleB79 and @lukaszgo1

### DIFF
--- a/.github/workflows/testWithNVDA.yaml
+++ b/.github/workflows/testWithNVDA.yaml
@@ -45,7 +45,7 @@ jobs:
   
     needs: addon
   
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     

--- a/addon/globalPlugins/emoticons/__init__.py
+++ b/addon/globalPlugins/emoticons/__init__.py
@@ -51,6 +51,12 @@ sD = speechDictHandler.SpeechDict()
 profileName = oldProfileName = None
 
 
+def disableInSecureMode(decoratedCls):
+	if globalVars.appArgs.secure:
+		return globalPluginHandler.GlobalPlugin
+	return decoratedCls
+
+
 def loadDic():
 	if profileName is None:
 		dicFile = ADDON_DIC_DEFAULT_FILE
@@ -74,6 +80,7 @@ def deactivateAnnouncement():
 			speechDictHandler.dictionaries["temp"].remove(entry)
 
 
+@disableInSecureMode
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	scriptCategory = SCRCAT_SPEECH


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
The add-on is not very useful on secure screens and it allows to save dictionaries, not accepted in NVDA.
### Description of how this pull request fixes the issue:
Use code provided by @CyrilleB79 and @lukaszgo1

### Testing performed:
Tested in other add-ons
### Known issues with pull request:
The add-on won't be available on secure screens.
### Change log entry:
* The add-on cannot be used on secure screens.