### PR TITLE
Compatibility with NVDA 2023.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion": "2022.1",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2022.3",
+	"addon_lastTestedNVDAVersion": "2023.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,11 @@ These are the key commands available by default, you can edit those or add new k
 
 Note: On Windows 10 and higher, it's also possible to use the built-in emoji panel.
 
+
+## Changes for 16.0 ##
+
+* Compatible with NVDA 2023.1.
+
 ## Changes for 15.0 ##
 
 * Requires NVDA 2022.1 or later.


### PR DESCRIPTION
## Link to issue number:

### Summary of the issue:
Add-ons need to be updated to be compatible with NVDA 2023.1.
### Description of how this pull request fixes the issue:
Set last tested version to 2023.1.
### Testing performed:
Code has been checked.
### Known issues with pull request:
None
### Change log entry:
* Compatible with NVDA 2023.1.