### PR TITLE
Add ability to copy various symbols

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"redhat.vscode-yaml"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+    "editor.accessibilitySupport": "on",
+    "python.linting.enabled": true,
+    "python.linting.maxNumberOfProblems": 10000,
+    "python.linting.flake8Args": [
+        "--config=flake8.ini"
+    ],
+    "python.linting.flake8Enabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.autoComplete.extraPaths": [
+        "../nvda/source",
+        "../nvda/miscDeps/python"
+        ],	
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "editor.insertSpaces": false,
+    "python.analysis.diagnosticSeverityOverrides": {
+        "reportUndefinedVariable": "none"
+    },
+    "python.analysis.extraPaths": [
+        "../nvda/source",
+        "../nvda/miscDeps/python"
+    ],
+    "python.defaultInterpreterPath": "../nvda/.venv/scripts/python.exe"
+}

--- a/addon/globalPlugins/emoticons/__init__.py
+++ b/addon/globalPlugins/emoticons/__init__.py
@@ -634,7 +634,8 @@ class InsertSymbolDialog(SpeechSymbolsDialog):
 		symbol = None
 		if index >= 0:
 			symbol = self.filteredSymbols[index]
-		self.symbolsToCopyEdit.SetValue(f"{self.symbolsToCopyEdit.GetValue()}{symbol.identifier}")
+			self.symbolsToCopyEdit.SetValue(f"{self.symbolsToCopyEdit.GetValue()}{symbol.identifier}")
+			speech.speakTypedCharacters(symbol.identifier)
 
 	def postInit(self):
 		self.filterEdit.SetFocus()

--- a/addon/globalPlugins/emoticons/__init__.py
+++ b/addon/globalPlugins/emoticons/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
-# Copyright (C) 2013-2022 Noelia Ruiz Martínez, Mesar Hameed, Francisco Javier Estrada Martínez
+# Copyright (C) 2013-2023 Noelia Ruiz Martínez, Mesar Hameed, Francisco Javier Estrada Martínez
 # Released under GPL 2
 
 import os

--- a/addon/globalPlugins/emoticons/__init__.py
+++ b/addon/globalPlugins/emoticons/__init__.py
@@ -605,6 +605,21 @@ class InsertSymbolDialog(SpeechSymbolsDialog):
 		# Translators: The label for a column in symbols list used to identify a replacement.
 		self.symbolsList.InsertColumn(1, translate("Replacement"))
 
+		bHelper = guiHelper.ButtonHelper(orientation=wx.HORIZONTAL)
+		bHelper.addButton(
+			parent=self,
+			# Translators: The label for a button in the Insert symbol dialog.
+			label=_("&Add")
+		).Bind(wx.EVT_BUTTON, self.onCopyClick)
+
+		# Translators: The label of a text field to copy symbols in the Insert Symbol dialog.
+		symbolsToCopyText = _("Symbols to &copy:")
+		self.symbolsToCopyEdit = sHelper.addLabeledControl(
+			labelText=symbolsToCopyText,
+			wxCtrlClass=wx.TextCtrl,
+			size=(self.scaleSize(310), -1),
+		)
+
 		self.filterEdit.Bind(wx.EVT_TEXT, self.onFilterEditTextChange)
 		self.filter()
 
@@ -614,15 +629,25 @@ class InsertSymbolDialog(SpeechSymbolsDialog):
 		except Exception:
 			pass
 
-	def postInit(self):
-		self.filterEdit.SetFocus()
-
-	def onOk(self, evt):
+	def onCopyClick(self, evt):
 		index = self.symbolsList.GetFirstSelected()
 		symbol = None
 		if index >= 0:
 			symbol = self.filteredSymbols[index]
-		if symbol is not None and api.copyToClip(symbol.identifier):
+		self.symbolsToCopyEdit.SetValue(f"{self.symbolsToCopyEdit.GetValue()}{symbol.identifier}")
+
+	def postInit(self):
+		self.filterEdit.SetFocus()
+
+	def onOk(self, evt):
+		if self.symbolsToCopyEdit.GetValue() == "":
+			index = self.symbolsList.GetFirstSelected()
+			symbol = None
+			if index >= 0:
+				symbol = self.filteredSymbols[index].identifier
+		else:
+			symbol = self.symbolsToCopyEdit.GetValue()
+		if symbol is not None and api.copyToClip(symbol):
 			# Translators: This is the message when symbol has been copied to the clipboard.
 			core.callLater(100, ui.message, _("Symbol copied to clipboard, ready for you to paste."))
 		else:

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,11 @@ When you press OK, the characters for the chosen emoticon will be copied to your
 
 ## Insert symbol ##
 
-This dialog allows you to choose one of the symbols available in the Punctuation/symbol pronunciation dialog of NVDA. You can use the Filter edit box or the arrow keys to select an item from the symbols list. Then, press OK and the selected emoji or symbol will be copied to your clipboard, ready for pasting.
+This dialog allows you to choose one of the symbols available in the Punctuation/symbol pronunciation dialog of NVDA. You can use the Filter edit box or the arrow keys to select an item from the symbols list.
+
+If you want to copy various symbols, use the Add button to append them to the Symbols to copy edit box.
+
+Then, press OK and the selected emoji or symbol, or the symbols contained in the mentioned edit box, will be copied to your clipboard, ready for pasting.
 
 ## Emoticons dictionary ##
 


### PR DESCRIPTION
## Link to issue number:
Fixes issue #33 
### Summary of the issue:
Added ability to copy more than one symbol.
### Description of how this pull request fixes the issue:
An edit box has been added to the Insert Symbols dialog, and a button to apend the selected symbol to this field.
If this edit box is empty, the selected symbol will be copied when pressing OK. Otherwise, the symbols contained in the edit box will be copied.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
* Added ability to copy various symbols at the same time.