### PR TITLE
Use WritePaths instead of speechDictHandler.speechDictVars.speechDictsPath

### DIFF
--- a/addon/globalPlugins/emoticons/__init__.py
+++ b/addon/globalPlugins/emoticons/__init__.py
@@ -24,6 +24,7 @@ from gui import guiHelper, nvdaControls
 from gui.settingsDialogs import NVDASettingsDialog, SettingsPanel, SpeechSymbolsDialog
 from gui.speechDict import DictionaryDialog
 from globalCommands import SCRCAT_SPEECH, SCRCAT_TOOLS, SCRCAT_CONFIG, SCRCAT_TEXTREVIEW
+from NVDAState import WritePaths
 from scriptHandler import script
 
 from .smileysList import emoticons
@@ -34,7 +35,7 @@ addonHandler.initTranslation()
 
 # Constants
 ADDON_DICTS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "emoticons"))
-EXPORT_DICTS_PATH = os.path.join(speechDictHandler.speechDictsPath, "emoticons")
+EXPORT_DICTS_PATH = os.path.join(WritePaths.speechDictsDir, "emoticons")
 ADDON_DIC_DEFAULT_FILE = os.path.join(ADDON_DICTS_PATH, "emoticons.dic")
 ADDON_SUMMARY = addonHandler.getCodeAddon().manifest["summary"]
 ADDON_PANEL_TITLE = ADDON_SUMMARY

--- a/buildVars.py
+++ b/buildVars.py
@@ -27,9 +27,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2022.1",
+	"addon_minimumNVDAVersion": "2023.2",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.1",
+	"addon_lastTestedNVDAVersion": "2023.2",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,10 @@ These are the key commands available by default, you can edit those or add new k
 
 Note: On Windows 10 and higher, it's also possible to use the built-in emoji panel.
 
+## Changes for 22.0.0 ##
+
+* Requires NVDA 2023.2 or later.
+
 ## Changes for 17.0 ##
 
 * Added ability to associate gestures to type symbols.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
speechDictHandler.speechDictVars.speechDictsPath has been deprecated in favour of WritePaths.speechDictsDir
### Description of how this pull request fixes the issue:
Use WritePaths.speechDictsDir
### Testing performed:
None yet.
### Known issues with pull request:
This will require NVDA 2023.2
### Change log entry:
* Requires NVDA 2023.2 or later.