### PR TITLE
Use public popupSettingsDialog function

### DIFF
--- a/addon/globalPlugins/emoticons/__init__.py
+++ b/addon/globalPlugins/emoticons/__init__.py
@@ -190,16 +190,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 						pass
 
 	def onInsertEmoticonDialog(self, evt):
-		gui.mainFrame._popupSettingsDialog(InsertEmoticonDialog)
+		gui.mainFrame.popupSettingsDialog(InsertEmoticonDialog)
 
 	def onInsertSymbolDialog(self, evt):
-		gui.mainFrame._popupSettingsDialog(InsertSymbolDialog)
+		gui.mainFrame.popupSettingsDialog(InsertSymbolDialog)
 
 	def onEmDicDialog(self, evt):
-		gui.mainFrame._popupSettingsDialog(EmDicDialog)
+		gui.mainFrame.popupSettingsDialog(EmDicDialog)
 
 	def onSettingsPanel(self, evt):
-		gui.mainFrame._popupSettingsDialog(NVDASettingsDialog, AddonSettingsPanel)
+		gui.mainFrame.popupSettingsDialog(NVDASettingsDialog, AddonSettingsPanel)
 
 	@script(
 		# Translators: Message presented in input help mode.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
NVDA 2023.2 uses popupSettingsDialog public function.
### Description of how this pull request fixes the issue:
The old private function has been replaced by the public one.
### Testing performed:
None yet.
### Known issues with pull request:
None
### Change log entry:
* Requires NVDA 2023.2 or later.