### PR TITLE
Use ssecureBrowseableMessage, by @CyrilleB79

### DIFF
--- a/addon/globalPlugins/emoticons/__init__.py
+++ b/addon/globalPlugins/emoticons/__init__.py
@@ -29,6 +29,7 @@ from scriptHandler import script
 
 from .smileysList import emoticons
 from .skipTranslation import translate
+from .securityUtils import secureBrowseableMessage  # Created by Cyrille (@CyrilleB79)
 
 
 addonHandler.initTranslation()
@@ -285,7 +286,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		languageDescription = languageHandler.getLanguageDescription(curLanguage)
 		# Translators: title for expanded symbol dialog. Example: "Expanded symbol (English)"
 		title = _("Symbol at the review cursor position ({})").format(languageDescription)
-		ui.browseableMessage(message, title)
+		secureBrowseableMessage(message, title)
 
 	@script(
 		# Translators: Message presented in input help mode.
@@ -317,7 +318,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		languageDescription = languageHandler.getLanguageDescription(curLanguage)
 		# Translators: title for expanded symbol dialog. Example: "Expanded symbol (English)"
 		title = _("Symbol at the caret position ({})").format(languageDescription)
-		ui.browseableMessage(message, title)
+		secureBrowseableMessage(message, title)
 
 
 class EmoticonFilter(object):

--- a/addon/globalPlugins/emoticons/securityUtils.py
+++ b/addon/globalPlugins/emoticons/securityUtils.py
@@ -1,0 +1,43 @@
+# -*- coding: UTF-8 -*-
+# NVDA add-on: Character Information
+# Copyright (C) 2024 Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING.txt for more details.
+
+import ui
+import buildVersion
+
+nvdaTranslations = _
+
+currentVersion = (buildVersion.version_year, buildVersion.version_major, buildVersion.version_minor)
+
+
+def secureBrowseableMessage(message, title=None, isHtml=False):
+	"""Call securely `ui.browseableMessage`.
+
+	`ui.browseableMessage` is impacted by GHSA-xg6w-23rw-39r8
+	(see https://github.com/nvaccess/nvda/security/advisories/GHSA-xg6w-23rw-39r8#event-132994)
+	This function should be used instead if you do not fully control what is passed as title of
+	`ui.browseableMessage`.
+	"""
+
+	if not hasFix_GHSA_xg6w_23rw_39r8():
+		# NVDA <= 2023.3.3
+		if title is None:
+			# The translation of NVDA's ui.browseableMessage title
+			titleToCheck = nvdaTranslations("NVDA Message")
+		else:
+			titleToCheck = title
+		if currentVersion < (2023, 1, 0):
+			# Before #14668 (NVDA < 2023.1)
+			sep = ";"
+		else:
+			sep = "__NVDA:split-here__"
+		if sep in titleToCheck:
+			raise RuntimeError('"{sep}" not allowed in the title of browseable messages'.format(sep=sep))
+	return ui.browseableMessage(message, title, isHtml)
+
+
+def hasFix_GHSA_xg6w_23rw_39r8():
+	fixedVersion = (2023, 3, 3)
+	return currentVersion >= fixedVersion


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:

https://github.com/nvaccess/nvda/security/advisories/GHSA-xg6w-23rw-39r8

### Description of how this pull request fixes the issue:

Used secureBrowseableMessage function, created by @CyrilleB79

### Testing performed:

Tested locally

### Known issues with pull request:

None

### Change log entry:

None